### PR TITLE
tournament tweaks

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -204,14 +204,14 @@ final class Api(
     }
 
   def tournament(id: String) =
-    ApiRequest { implicit req =>
+    AnonOrScoped() { implicit req => { me =>
       env.tournament.tournamentRepo byId id flatMap {
         _ ?? { tour =>
           val page = (getInt("page", req) | 1) atLeast 1 atMost 200
           env.tournament.jsonView(
             tour = tour,
             page = page.some,
-            me = none,
+            me = me,
             getUserTeamIds = _ => fuccess(Nil),
             getTeamName = env.team.getTeamName.apply,
             playerInfoExt = none,
@@ -220,8 +220,8 @@ final class Api(
             withScores = true
           )(reqLang) map some
         }
-      } map toApiResult
-    }
+      }map (JsonOk(_))
+    } }
 
   def tournamentGames(id: String) =
     Action.async { req =>

--- a/modules/tournament/src/main/TournamentScheduler.scala
+++ b/modules/tournament/src/main/TournamentScheduler.scala
@@ -20,6 +20,7 @@ final private class TournamentScheduler(
   import Schedule.Plan
   import chess.variant._
 
+  /*
   ResilientScheduler(every = Every(5 minutes), timeout = AtMost(1 minute), initialDelay = 1 minute) {
     tournamentRepo.scheduledUnfinished flatMap { dbScheds =>
       try {
@@ -33,6 +34,7 @@ final private class TournamentScheduler(
       }
     }
   }
+   */
 
   /* Month plan:
    * First week: Shield standard tournaments


### PR DESCRIPTION
- /api/tournament/id accepts an auth token; when present populates the `.me` field
- /api/tournaments returns all tournaments; including non-default ones
- no longer automatically schedule default tournaments