### PR TITLE
Return all created tournaments instead of just those starting soon

### DIFF
--- a/modules/tournament/src/main/TournamentRepo.scala
+++ b/modules/tournament/src/main/TournamentRepo.scala
@@ -201,8 +201,8 @@ final class TournamentRepo(val coll: Coll, playerCollName: CollName)(implicit
   def featuredGameId(tourId: Tournament.ID) = coll.primitiveOne[Game.ID]($id(tourId), "featured")
 
   private def startingSoonSelect(aheadMinutes: Int) =
-    createdSelect ++
-      $doc("startsAt" $lt (DateTime.now plusMinutes aheadMinutes))
+    createdSelect // ++
+      // $doc("startsAt" $lt (DateTime.now plusMinutes aheadMinutes))
 
   def scheduledCreated(aheadMinutes: Int): Fu[List[Tournament]] =
     coll.list[Tournament](startingSoonSelect(aheadMinutes))


### PR DESCRIPTION
this PR makes the /api/tournament endpoint return all upcoming tournaments in the `created` field of the api response, not just those starting within 6 hours