### PR TITLE
filtering podium by has played at least one game

### DIFF
--- a/modules/tournament/src/main/BSONHandlers.scala
+++ b/modules/tournament/src/main/BSONHandlers.scala
@@ -145,7 +145,8 @@ object BSONHandlers {
         score = r intD "s",
         fire = r boolD "f",
         performance = r intD "e",
-        team = r strO "t"
+        team = r strO "t",
+        played = r boolD "f"
       )
     def writes(w: BSON.Writer, o: Player) =
       $doc(
@@ -159,7 +160,8 @@ object BSONHandlers {
         "m"   -> o.magicScore,
         "f"   -> w.boolO(o.fire),
         "e"   -> o.performance,
-        "t"   -> o.team
+        "t"   -> o.team,
+        "pl"  -> o.played
       )
   }
 

--- a/modules/tournament/src/main/BSONHandlers.scala
+++ b/modules/tournament/src/main/BSONHandlers.scala
@@ -146,7 +146,7 @@ object BSONHandlers {
         fire = r boolD "f",
         performance = r intD "e",
         team = r strO "t",
-        played = r boolD "f"
+        played = r boolD "pl"
       )
     def writes(w: BSON.Writer, o: Player) =
       $doc(

--- a/modules/tournament/src/main/JsonView.scala
+++ b/modules/tournament/src/main/JsonView.scala
@@ -547,7 +547,8 @@ object JsonView {
         .obj(
           "name"   -> light.fold(p.userId)(_.name),
           "rank"   -> rankedPlayer.rank,
-          "rating" -> p.rating
+          "rating" -> p.rating,
+          "score" -> p.score
         )
         .add("sheet", sheet.map(sheetJson(streakable = streakable, withScores = withScores)))
         .add("title" -> light.flatMap(_.title))

--- a/modules/tournament/src/main/JsonView.scala
+++ b/modules/tournament/src/main/JsonView.scala
@@ -6,19 +6,17 @@ import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import play.api.i18n.Lang
 import play.api.libs.json._
-
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
 import lila.common.Json._
-import lila.common.{GreatPlayer, LightUser, Preload, Uptime}
-import lila.game.{Game, LightPov}
+import lila.common.{ GreatPlayer, LightUser, Preload, Uptime }
+import lila.game.{ Game, LightPov }
 import lila.hub.LightTeam.TeamID
 import lila.memo.CacheApi._
 import lila.memo.SettingStore
 import lila.rating.PerfType
 import lila.socket.Socket.SocketVersion
-import lila.tournament.arena.Sheet
-import lila.user.{LightUserApi, User}
+import lila.user.{ LightUserApi, User }
 
 final class JsonView(
     lightUserApi: LightUserApi,
@@ -522,13 +520,6 @@ object JsonView {
         .add("team" -> player.team)
   }
 
-  private def sheetNbs(s: arena.Sheet) =
-    Json.obj(
-      "game" -> s.scores.size,
-      "berserk" -> s.scores.count(_.isBerserk),
-      "win" -> s.scores.count(_.res == arena.Sheet.Result.Win)
-    )
-
   def playerJson(
       lightUserApi: LightUserApi,
       sheets: Map[User.ID, arena.Sheet],
@@ -556,16 +547,13 @@ object JsonView {
         .obj(
           "name"   -> light.fold(p.userId)(_.name),
           "rank"   -> rankedPlayer.rank,
-          "rating" -> p.rating,
-          "score"  -> p.score,
-          "nb"     -> sheetNbs(sheet.getOrElse(Sheet(Nil, 0)))
+          "rating" -> p.rating
         )
         .add("sheet", sheet.map(sheetJson(streakable = streakable, withScores = withScores)))
         .add("title" -> light.flatMap(_.title))
         .add("provisional" -> p.provisional)
         .add("withdraw" -> p.withdraw)
         .add("team" -> p.team)
-        .add("performance" -> p.performanceOption)
     }
   }
 

--- a/modules/tournament/src/main/Player.scala
+++ b/modules/tournament/src/main/Player.scala
@@ -55,6 +55,7 @@ private[tournament] object Player {
       userId = user.id,
       rating = user.perfs(perfType).intRating,
       provisional = user.perfs(perfType).provisional,
-      team = team
+      team = team,
+      played = false
     )
 }

--- a/modules/tournament/src/main/Player.scala
+++ b/modules/tournament/src/main/Player.scala
@@ -15,7 +15,8 @@ private[tournament] case class Player(
     score: Int = 0,
     fire: Boolean = false,
     performance: Int = 0,
-    team: Option[TeamID] = None
+    team: Option[TeamID] = None,
+    played: Boolean = false,
 ) {
 
   def id = _id

--- a/modules/tournament/src/main/PlayerRepo.scala
+++ b/modules/tournament/src/main/PlayerRepo.scala
@@ -21,6 +21,7 @@ final class PlayerRepo(coll: Coll)(implicit ec: scala.concurrent.ExecutionContex
   private val selectActive   = $doc("w" $ne true)
   private val selectWithdraw = $doc("w" -> true)
   private val bestSort       = $doc("m" -> -1)
+  private val selectPlayed       = $doc("pl" -> true)
 
   def byId(id: Tournament.ID): Fu[Option[Player]] = coll.one[Player]($id(id))
 
@@ -36,7 +37,7 @@ final class PlayerRepo(coll: Coll)(implicit ec: scala.concurrent.ExecutionContex
     }
 
   private[tournament] def bestByTour(tourId: Tournament.ID, nb: Int, skip: Int = 0): Fu[List[Player]] =
-    coll.find(selectTour(tourId)).sort(bestSort).skip(skip).cursor[Player]().list(nb)
+    coll.find(selectTour(tourId) ++ selectPlayed).sort(bestSort).skip(skip).cursor[Player]().list(nb)
 
   private[tournament] def bestByTourWithRank(
       tourId: Tournament.ID,

--- a/modules/tournament/src/main/PlayerRepo.scala
+++ b/modules/tournament/src/main/PlayerRepo.scala
@@ -21,7 +21,7 @@ final class PlayerRepo(coll: Coll)(implicit ec: scala.concurrent.ExecutionContex
   private val selectActive   = $doc("w" $ne true)
   private val selectWithdraw = $doc("w" -> true)
   private val bestSort       = $doc("m" -> -1)
-  private val selectPlayed       = $doc("pl" -> true)
+  private val selectPlayed   = $doc("pl" -> true)
 
   def byId(id: Tournament.ID): Fu[Option[Player]] = coll.one[Player]($id(id))
 

--- a/modules/tournament/src/main/TournamentApi.scala
+++ b/modules/tournament/src/main/TournamentApi.scala
@@ -438,7 +438,7 @@ final class TournamentApi(
         cached.sheet.addResult(tour, userId, pairing).map { sheet =>
           player.copy(
             score = sheet.total,
-            played = true,
+            played = sheet.scores.size > 0,
             fire = tour.streakable && sheet.isOnFire,
             rating = perf.fold(player.rating)(_.intRating),
             provisional = perf.fold(player.provisional)(_.provisional),
@@ -521,7 +521,8 @@ final class TournamentApi(
             score = sheet.total,
             fire = tour.streakable && sheet.isOnFire,
             rating = perf.fold(player.rating)(_.intRating),
-            provisional = perf.fold(player.provisional)(_.provisional)
+            provisional = perf.fold(player.provisional)(_.provisional),
+            played = sheet.scores.size > 0
           )
         }
       }
@@ -542,7 +543,8 @@ final class TournamentApi(
             playerRepo.update(
               player.copy(
                 score = sheet.total,
-                fire = tour.streakable && sheet.isOnFire
+                fire = tour.streakable && sheet.isOnFire,
+                played = sheet.scores.size > 0
               )
             )
           }

--- a/modules/tournament/src/main/TournamentApi.scala
+++ b/modules/tournament/src/main/TournamentApi.scala
@@ -438,6 +438,7 @@ final class TournamentApi(
         cached.sheet.addResult(tour, userId, pairing).map { sheet =>
           player.copy(
             score = sheet.total,
+            played = true,
             fire = tour.streakable && sheet.isOnFire,
             rating = perf.fold(player.rating)(_.intRating),
             provisional = perf.fold(player.provisional)(_.provisional),


### PR DESCRIPTION
added a new flag "played" for Player that checks at least one game has been played. 

this was necessary to calculate the win rate on the podium, since we don't rank players that haven't played at least one game, so they shouldn't go on the podium, but the lichess api exposes more information in the `podium` like num games, num won, and performance (which is a ugly to extract from the scoresheet, due to streaks doubling points). 

i decided to just filter out the podium field on the lila side instead of supplementing the info to `fullStandings` bc `fullStandings` was becoming pretty large