### PR TITLE
loosen username permissions

### DIFF
--- a/modules/security/src/main/SecurityForm.scala
+++ b/modules/security/src/main/SecurityForm.scala
@@ -45,7 +45,7 @@ final class SecurityForm(
 
     val username = LilaForm.cleanNonEmptyText
       .verifying(
-        Constraints minLength 5,
+        Constraints minLength 3,
         Constraints maxLength 20,
         Constraints.pattern(
           regex = User.newUsernameRegex,


### PR DESCRIPTION
some primer usernames are 3 or 4 characters; ensure that those users can sign up for chess club